### PR TITLE
Update AssetMoverHelper.java

### DIFF
--- a/src/main/java/com/cleanroommc/assetmover/AssetMoverHelper.java
+++ b/src/main/java/com/cleanroommc/assetmover/AssetMoverHelper.java
@@ -28,7 +28,7 @@ public enum AssetMoverHelper {
 
     private static final String USER_AGENT = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/107.0.0.0 Safari/537.36 Edg/107.0.1418.42";
     private static final String VERSIONS_MANIFEST = "https://launchermeta.mojang.com/mc/game/version_manifest.json";
-    private static final String RESOURCES_URL = "http://resources.download.minecraft.net/";
+    private static final String RESOURCES_URL = "https://resources.download.minecraft.net/";
 
     private static ExecutorService EXECUTOR;
     private static Map<String, Path> URL_FILES = new Object2ObjectOpenHashMap<>();


### PR DESCRIPTION
Replaced unsecured http with secured https to fix error: [AssetMover Executor #0/FATAL] [AssetMover]: Unexpected error occurred while downloading asset 'assets/minecraft/sounds/block/bubble_column/bubble2.ogg' java.io.IOException: Server returned HTTP response code: 400 for URL: http://resources.download.minecraft.net/ae/ae1490438f67b186d9d92a3dd0fbb6eaa604b31d