### PR TITLE
fix NPE in haltAndFlush by not nulling the asset caches

### DIFF
--- a/src/main/java/com/cleanroommc/assetmover/AssetMoverHelper.java
+++ b/src/main/java/com/cleanroommc/assetmover/AssetMoverHelper.java
@@ -56,9 +56,9 @@ public enum AssetMoverHelper {
         }
         AssetMoverAPI.LOGGER.info("Clearing cache...");
 
-        URL_FILES = null;
-        VERSION_ASSET_INFO = null;
-        ASSET_MAPPING = null;
+        URL_FILES = new Object2ObjectOpenHashMap<>();
+        VERSION_ASSET_INFO = new Object2ObjectOpenHashMap<>();
+        ASSET_MAPPING = new Object2ObjectOpenHashMap<>();
         VERSIONS_ARRAY = null;
     }
 


### PR DESCRIPTION
haltAndFlush() sets URL_FILES, VERSION_ASSET_INFO, and ASSET_MAPPING to null
when it runs. it's called from InternalResourcePack.getResourceDomains(),
which can apparently fire *before* a mod's FMLConstructionEvent finishes
calling AssetMoverAPI.fromMinecraft(...). when that happens, getVersionJson
hits VERSION_ASSET_INFO.get(version) on a null map and throws an NPE,
crashing on launch.

ran into this with Subaquatic - load order timing meant haltAndFlush ran
before Subaquatic's construction event call, instant NPE every time.

this just reinitializes the three maps to empty Object2ObjectOpenHashMaps
instead of nulling them, so "flush" still clears the cache but doesn't leave
the fields in an unusable state. left VERSIONS_ARRAY as null since every read
site already null-checks it and lazily refetches anyway.

tested locally, fixes the crash, no other side effects i could find.